### PR TITLE
Use markdown mailable

### DIFF
--- a/src/app/Notifications/MailResetPasswordNotification.php
+++ b/src/app/Notifications/MailResetPasswordNotification.php
@@ -51,7 +51,7 @@ class MailResetPasswordNotification extends Notification implements ShouldQueue
         return (new MailMessage)
             ->from(config('mail.from.address'), config('mail.from.name'))
             ->subject(__('mage.auth.reset-password.email.subject'))
-            ->view('mage::pages.auth.reset-email', [
+            ->markdown('mage::pages.auth.reset-email', [
                 "token" => $this->token
             ]);
     }

--- a/src/app/Notifications/MailWelcomeNotification.php
+++ b/src/app/Notifications/MailWelcomeNotification.php
@@ -43,6 +43,6 @@ class MailWelcomeNotification extends Notification implements ShouldQueue
         return (new MailMessage)
             ->from(config('mail.from.address'), config('mail.from.name'))
             ->subject(__('mage.auth.welcome-email.email.subject'))
-            ->view('mage::pages.auth.welcome-email');
+            ->markdown('mage::pages.auth.welcome-email');
     }
 }

--- a/src/app/Notifications/MailWelcomeWithoutPasswordNotification.php
+++ b/src/app/Notifications/MailWelcomeWithoutPasswordNotification.php
@@ -51,7 +51,7 @@ class MailWelcomeWithoutPasswordNotification extends Notification implements Sho
         return (new MailMessage)
             ->from(config('mail.from.address'), config('mail.from.name'))
             ->subject(__('mage.auth.welcome-password-reset-email.email.subject'))
-            ->view('mage::pages.auth.welcome-password-reset-email', [
+            ->markdown('mage::pages.auth.welcome-password-reset-email', [
                 "token" => $this->token
             ]);
     }


### PR DESCRIPTION
If we use the markdown option we can have better simpler emails by default.

If there are more mails I can change them all.